### PR TITLE
Update Min-Max_Guide.md

### DIFF
--- a/Min-Max_Guide.md
+++ b/Min-Max_Guide.md
@@ -281,7 +281,7 @@ Another alternative is to exploit RNG to farm clay, but this is illegal in our r
   - As soon as a tree starts to fall, walk towards where the wood will spawn and immediately pause the game. This prevents in-game time from passing, but the tree falling animation will still complete. Additionally, all of the wood will automatically be collected by the player while the game is still paused. (You should use this strategy whenever you are chopping trees and not bothering to kill the stumps.)
 - Once foraging level 1, craft a chest, place it next to the house, and empty all inventory except for scythe + axe + pickaxe + hoe.
 - Exit south to the forest. (The time should be around 9:20 AM.)
-- Check the entire map for forage to plan your route. Head generally clockwise: south first toward the Spring Onion area and ending up coming east from Traveling Cart area where you will meet Jas.
+- Use a screenshot and/or zoom to check the Secret Woods for foragables so that you can plan your route. Head south first toward the Spring Onion area. You should end up coming east from the Traveling Cart area where you will meet Jas.
   - Pick up all foragable items along the way.
   - Try to kill as many weeds as possible, but do not go too far out of your way for just 1 weed (since you need to make it to Jas at 11:20 AM).
 - Meet Jas as she walks from her house to her swing around 11:20 AM.

--- a/Min-Max_Guide.md
+++ b/Min-Max_Guide.md
@@ -281,7 +281,7 @@ Another alternative is to exploit RNG to farm clay, but this is illegal in our r
   - As soon as a tree starts to fall, walk towards where the wood will spawn and immediately pause the game. This prevents in-game time from passing, but the tree falling animation will still complete. Additionally, all of the wood will automatically be collected by the player while the game is still paused. (You should use this strategy whenever you are chopping trees and not bothering to kill the stumps.)
 - Once foraging level 1, craft a chest, place it next to the house, and empty all inventory except for scythe + axe + pickaxe + hoe.
 - Exit south to the forest. (The time should be around 9:20 AM.)
-- Head west past the Traveling Cart area, south to the Abandoned House, east to the Spring Onion area, and north to Marnie's Ranch.
+- Check the entire map for forage to plan your route. Head generally clockwise: south first toward the Spring Onion area and ending up coming east from Traveling Cart area where you will meet Jas.
   - Pick up all foragable items along the way.
   - Try to kill as many weeds as possible, but do not go too far out of your way for just 1 weed (since you need to make it to Jas at 11:20 AM).
 - Meet Jas as she walks from her house to her swing around 11:20 AM.
@@ -331,7 +331,7 @@ Another alternative is to exploit RNG to farm clay, but this is illegal in our r
 - Chop wood until around 4-6 energy left.
 - Kill weeds + grass until around 1:30 AM (assuming you have only a couple more Mixed Seeds).
 - Ship all but 20 fiber, all sap, all clay + all pinecones + extra spring foraging items + any food from the garbage cans (except for [Field Snack](https://stardewvalleywiki.com/Field_Snack)).
-  - In other words, keep stone + wood + coal + 20 fiber + 1 of each spring foragable.
+  - In other words, keep stone + wood + coal + 20 fiber + 1 of each spring foragable. If you will be much short of 1200 gp tomorrow without all the spring forageables, ship them too.
   - Normally, we would save Leeks, Dandelions, and food from the garbage cans to eat, since they have a low GPE. However, we need as much money as possible for Spring 2, so we need to sell them today as an exception to the rule.
 - Hoe + plant + water any remaining Mixed Seeds.
   - Note that you can work past 0 energy and become exhausted with no penalty carrying over to Spring 2 (because you will level up foraging).

--- a/Min-Max_Guide.md
+++ b/Min-Max_Guide.md
@@ -331,7 +331,8 @@ Another alternative is to exploit RNG to farm clay, but this is illegal in our r
 - Chop wood until around 4-6 energy left.
 - Kill weeds + grass until around 1:30 AM (assuming you have only a couple more Mixed Seeds).
 - Ship all but 20 fiber, all sap, all clay + all pinecones + extra spring foraging items + any food from the garbage cans (except for [Field Snack](https://stardewvalleywiki.com/Field_Snack)).
-  - In other words, keep stone + wood + coal + 20 fiber + 1 of each spring foragable. If you will be much short of 1200 gp tomorrow without all the spring forageables, ship them too.
+  - In other words, keep stone + wood + coal + 20 fiber + 1 of each spring foragable.
+    - If you are not lucky enough with getting money/foragables so far, it is probably better to not keep 1 of each spring foragable. Ship them so that you can buy the Iridium Rod faster on Spring 2, and worry about the Community Center quest later on.
   - Normally, we would save Leeks, Dandelions, and food from the garbage cans to eat, since they have a low GPE. However, we need as much money as possible for Spring 2, so we need to sell them today as an exception to the rule.
 - Hoe + plant + water any remaining Mixed Seeds.
   - Note that you can work past 0 energy and become exhausted with no penalty carrying over to Spring 2 (because you will level up foraging).


### PR DESCRIPTION
1. There is potential wasted time waiting for Emily to come from her room that can be used by meeting Jas a little later and further west if needed. Thus planning a clockwise trip (if any) around the lake may be better. This doesn't add travel time since we would have had to double north then south at the end anyway to catch Jas and Haley. Coming from the Secret Woods area at the end makes meeting Jas and Haley more natural and puts Emily in her living room at the risk of chasing Penny toward Marnie.

This worked a lot better than counter-clockwise (which just wasn't working for me) when I tested it. In fact, it seems that the optimal route may be to barely catch Haley before she gets too far south. Going out of the way for Marnie is just more weeds that aren't killed in the Forest, and there are plenty to kill near where Haley stops.

2. Against the event that Spring 1 goes financially poorly (no artifact and scant forage), should the guide recommend as edited?